### PR TITLE
Move logging event call into dedicated fluent interface log() method

### DIFF
--- a/src/main/java/com/youtube/hempfest/economy/construct/EconomyAction.java
+++ b/src/main/java/com/youtube/hempfest/economy/construct/EconomyAction.java
@@ -21,6 +21,8 @@ public class EconomyAction {
 
 	private final boolean success;
 
+	private boolean logged = false;
+
 	private final String info;
 
 	private final EconomyEntity holder;
@@ -30,14 +32,6 @@ public class EconomyAction {
 		this.success = success;
 		this.info = transactionInfo != null ? transactionInfo : "";
 		this.holder = holder;
-		final EconomyAction economyAction = this;
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				PM.callEvent(((amount != null) ? new AsyncTransactionEvent(economyAction) :
-						new AsyncEconomyInfoEvent(economyAction)));
-			}
-		}.runTaskAsynchronously(PLUGIN);
 	}
 
 	public EconomyAction(EconomyEntity holder, boolean success, String transactionInfo) {
@@ -76,5 +70,20 @@ public class EconomyAction {
 	 */
 	public String getInfo() {
 		return info;
+	}
+
+	public EconomyAction log() {
+		if (!logged) {
+			final EconomyAction economyAction = this;
+			new BukkitRunnable() {
+				@Override
+				public void run() {
+					PM.callEvent(((amount != null) ? new AsyncTransactionEvent(economyAction) :
+							new AsyncEconomyInfoEvent(economyAction)));
+				}
+			}.runTaskAsynchronously(PLUGIN);
+			logged = true;
+		}
+		return this;
 	}
 }

--- a/src/main/java/com/youtube/hempfest/economy/construct/entity/PlayerEconomyEntityBase.java
+++ b/src/main/java/com/youtube/hempfest/economy/construct/entity/PlayerEconomyEntityBase.java
@@ -35,6 +35,14 @@ public abstract class PlayerEconomyEntityBase implements EconomyEntity {
         return offlinePlayer;
     }
 
+    /**
+     * Get the OfflinePlayer's UniqueId
+     * @return {@link UUID} of the player
+     */
+    public UUID getUniqueId() {
+        return uid;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -44,6 +52,6 @@ public abstract class PlayerEconomyEntityBase implements EconomyEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id(), uid);
+        return Objects.hash(id());
     }
 }


### PR DESCRIPTION
Logging event call moved into dedicated `log()` method. Discrete addition of a getter for player's UniqueId, simplified hashcode (no need to hash id+uid when id contains uid+type prefix already.